### PR TITLE
Add asynchronous exchange rate workflows

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 
+	"github.com/example/rate_limiter/internal/exchange"
 	httpserver "github.com/example/rate_limiter/internal/http"
 	"github.com/example/rate_limiter/internal/limiter"
 	"github.com/example/rate_limiter/internal/user"
@@ -33,9 +34,17 @@ func main() {
 	repo := user.NewPostgresRepository(pool)
 
 	redisClient := redis.NewClient(&redis.Options{Addr: redisAddr})
+	defer redisClient.Close()
 	rl := limiter.NewRedis(redisClient, limit, ttl)
 
-	srv := httpserver.NewServer(repo, rl)
+	rateRetention := 7 * 24 * time.Hour
+	rateProvider := exchange.NewHTTPProvider(&http.Client{Timeout: 10 * time.Second})
+	rateStore := exchange.NewRedisStore(redisClient, rateRetention)
+	webhookNotifier := exchange.NewHTTPNotifier(&http.Client{Timeout: 5 * time.Second}, 5*time.Second)
+	exchangeService := exchange.NewService(rateProvider, rateStore, webhookNotifier)
+	defer exchangeService.Close()
+
+	srv := httpserver.NewServer(repo, rl, exchangeService)
 
 	addr := getenv("HTTP_ADDR", ":8080")
 	log.Printf("starting server on %s", addr)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.3
 require (
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/go-chi/chi/v5 v5.2.3
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/redis/go-redis/v9 v9.12.1
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
 github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/exchange/notifier.go
+++ b/internal/exchange/notifier.go
@@ -1,0 +1,51 @@
+package exchange
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Notifier dispatches completed jobs to webhook endpoints.
+type Notifier interface {
+	Notify(ctx context.Context, job *Job) error
+}
+
+type HTTPNotifier struct {
+	client  *http.Client
+	timeout time.Duration
+}
+
+func NewHTTPNotifier(client *http.Client, timeout time.Duration) *HTTPNotifier {
+	return &HTTPNotifier{client: client, timeout: timeout}
+}
+
+func (n *HTTPNotifier) Notify(ctx context.Context, job *Job) error {
+	payload, err := json.Marshal(job)
+	if err != nil {
+		return fmt.Errorf("marshal job: %w", err)
+	}
+	reqCtx := ctx
+	if n.timeout > 0 {
+		var cancel context.CancelFunc
+		reqCtx, cancel = context.WithTimeout(ctx, n.timeout)
+		defer cancel()
+	}
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, job.CallbackURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send webhook: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook unexpected status: %s", resp.Status)
+	}
+	return nil
+}

--- a/internal/exchange/notifier_test.go
+++ b/internal/exchange/notifier_test.go
@@ -1,0 +1,42 @@
+package exchange_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/example/rate_limiter/internal/exchange"
+)
+
+func TestHTTPNotifierSendsPayloadToWebhookClient(t *testing.T) {
+	received := make(chan exchange.Job, 1)
+	fakeClient := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var job exchange.Job
+		if err := json.NewDecoder(r.Body).Decode(&job); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		received <- job
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fakeClient.Close()
+
+	notifier := exchange.NewHTTPNotifier(fakeClient.Client(), time.Second)
+	job := &exchange.Job{ID: "job", Status: exchange.JobStatusCompleted, CallbackURL: fakeClient.URL}
+
+	if err := notifier.Notify(context.Background(), job); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+
+	select {
+	case got := <-received:
+		if got.ID != job.ID {
+			t.Fatalf("expected job id %s, got %s", job.ID, got.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive webhook payload")
+	}
+}

--- a/internal/exchange/provider.go
+++ b/internal/exchange/provider.go
@@ -1,0 +1,86 @@
+package exchange
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// RateProvider retrieves currency exchange rates from an upstream service.
+type RateProvider interface {
+	FetchRate(ctx context.Context, base, quote string) (*Rate, error)
+}
+
+// HTTPProvider implements RateProvider using a public HTTP API.
+type HTTPProvider struct {
+	client *http.Client
+	host   string
+}
+
+// HTTPProviderOption configures HTTPProvider.
+type HTTPProviderOption func(*HTTPProvider)
+
+// WithHTTPProviderHost overrides the API host. Useful for tests.
+func WithHTTPProviderHost(host string) HTTPProviderOption {
+	return func(p *HTTPProvider) {
+		p.host = host
+	}
+}
+
+// NewHTTPProvider creates a provider that calls exchangerate.host by default.
+func NewHTTPProvider(client *http.Client, opts ...HTTPProviderOption) *HTTPProvider {
+	p := &HTTPProvider{
+		client: client,
+		host:   "https://api.exchangerate.host",
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+type httpProviderResponse struct {
+	Rates map[string]float64 `json:"rates"`
+	Date  string             `json:"date"`
+	Base  string             `json:"base"`
+}
+
+// FetchRate queries the upstream API for the provided pair.
+func (p *HTTPProvider) FetchRate(ctx context.Context, base, quote string) (*Rate, error) {
+	base = strings.ToUpper(base)
+	quote = strings.ToUpper(quote)
+
+	endpoint := fmt.Sprintf("%s/latest", strings.TrimRight(p.host, "/"))
+	q := url.Values{}
+	q.Set("base", base)
+	q.Set("symbols", quote)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?"+q.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	var payload httpProviderResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	value, ok := payload.Rates[quote]
+	if !ok {
+		return nil, fmt.Errorf("missing rate for %s", quote)
+	}
+	asOf, err := time.Parse("2006-01-02", payload.Date)
+	if err != nil {
+		return nil, fmt.Errorf("parse date: %w", err)
+	}
+	return &Rate{Base: base, Quote: quote, Value: value, AsOf: asOf.UTC()}, nil
+}

--- a/internal/exchange/service.go
+++ b/internal/exchange/service.go
@@ -1,0 +1,220 @@
+package exchange
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type jobRequest struct {
+	jobID       string
+	base        string
+	quote       string
+	callbackURL string
+}
+
+type ServiceOption func(*Service)
+
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now().UTC() }
+
+type Service struct {
+	provider       RateProvider
+	store          Store
+	notifier       Notifier
+	processTimeout time.Duration
+	clock          Clock
+
+	queue chan jobRequest
+	wg    sync.WaitGroup
+	once  sync.Once
+}
+
+func WithProcessTimeout(d time.Duration) ServiceOption {
+	return func(s *Service) { s.processTimeout = d }
+}
+
+func WithClock(clock Clock) ServiceOption {
+	return func(s *Service) { s.clock = clock }
+}
+
+func WithQueueSize(size int) ServiceOption {
+	return func(s *Service) { s.queue = make(chan jobRequest, size) }
+}
+
+func NewService(provider RateProvider, store Store, notifier Notifier, opts ...ServiceOption) *Service {
+	s := &Service{
+		provider:       provider,
+		store:          store,
+		notifier:       notifier,
+		processTimeout: 2 * time.Minute,
+		clock:          realClock{},
+		queue:          make(chan jobRequest, 32),
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	s.wg.Add(1)
+	go s.worker()
+	return s
+}
+
+func (s *Service) Close() {
+	s.once.Do(func() {
+		close(s.queue)
+		s.wg.Wait()
+	})
+}
+
+func (s *Service) RequestRate(ctx context.Context, base, quote string) (*Job, error) {
+	return s.requestRate(ctx, base, quote, "")
+}
+
+func (s *Service) RequestRateWithWebhook(ctx context.Context, base, quote, callbackURL string) (*Job, error) {
+	if strings.TrimSpace(callbackURL) == "" {
+		return nil, fmt.Errorf("callback url required")
+	}
+	return s.requestRate(ctx, base, quote, callbackURL)
+}
+
+func (s *Service) requestRate(ctx context.Context, base, quote, callbackURL string) (*Job, error) {
+	base = strings.ToUpper(base)
+	quote = strings.ToUpper(quote)
+
+	today := s.clock.Now().Truncate(24 * time.Hour)
+	if rate, err := s.store.GetRateForDay(ctx, base, quote, today); err == nil {
+		now := s.clock.Now()
+		job := &Job{
+			ID:        uuid.NewString(),
+			Status:    JobStatusCompleted,
+			Rate:      rate,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if callbackURL != "" {
+			job.CallbackURL = callbackURL
+		}
+		if err := s.store.SaveJob(ctx, job); err != nil {
+			return nil, err
+		}
+		if callbackURL != "" && s.notifier != nil {
+			go s.dispatchWebhook(job)
+		}
+		return job, nil
+	} else if err != nil && err != ErrNotFound {
+		return nil, err
+	}
+
+	now := s.clock.Now()
+	job := &Job{
+		ID:          uuid.NewString(),
+		Status:      JobStatusPending,
+		CallbackURL: callbackURL,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := s.store.SaveJob(ctx, job); err != nil {
+		return nil, err
+	}
+	req := jobRequest{jobID: job.ID, base: base, quote: quote, callbackURL: callbackURL}
+	select {
+	case s.queue <- req:
+		return job, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (s *Service) GetJob(ctx context.Context, id string) (*Job, error) {
+	return s.store.GetJob(ctx, id)
+}
+
+func (s *Service) GetRateForDay(ctx context.Context, base, quote string, day time.Time) (*Rate, error) {
+	base = strings.ToUpper(base)
+	quote = strings.ToUpper(quote)
+	return s.store.GetRateForDay(ctx, base, quote, day.Truncate(24*time.Hour))
+}
+
+func (s *Service) worker() {
+	defer s.wg.Done()
+	for req := range s.queue {
+		if err := s.handleJob(req); err != nil {
+			log.Printf("process job %s failed: %v", req.jobID, err)
+		}
+	}
+}
+
+func (s *Service) handleJob(req jobRequest) error {
+	ctx := context.Background()
+	if s.processTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.processTimeout)
+		defer cancel()
+	}
+	job, err := s.store.GetJob(ctx, req.jobID)
+	if err != nil {
+		return fmt.Errorf("load job: %w", err)
+	}
+
+	today := s.clock.Now().Truncate(24 * time.Hour)
+	rate, err := s.store.GetRateForDay(ctx, req.base, req.quote, today)
+	if err != nil && err != ErrNotFound {
+		return fmt.Errorf("lookup cached rate: %w", err)
+	}
+	if err == ErrNotFound {
+		rate, err = s.provider.FetchRate(ctx, req.base, req.quote)
+		if err != nil {
+			job.Status = JobStatusFailed
+			job.Failure = err.Error()
+			job.UpdatedAt = s.clock.Now()
+			return s.store.SaveJob(ctx, job)
+		}
+		if rate.AsOf.IsZero() {
+			rate.AsOf = today
+		}
+		if err := s.store.SaveRate(ctx, rate); err != nil {
+			job.Status = JobStatusFailed
+			job.Failure = fmt.Sprintf("save rate: %v", err)
+			job.UpdatedAt = s.clock.Now()
+			return s.store.SaveJob(ctx, job)
+		}
+	}
+	job.Status = JobStatusCompleted
+	job.Rate = rate
+	job.Failure = ""
+	job.UpdatedAt = s.clock.Now()
+	if err := s.store.SaveJob(ctx, job); err != nil {
+		return fmt.Errorf("update job: %w", err)
+	}
+	if job.CallbackURL != "" && s.notifier != nil {
+		if err := s.notifier.Notify(context.Background(), job); err != nil {
+			job.Status = JobStatusFailed
+			job.Failure = fmt.Sprintf("webhook: %v", err)
+			job.UpdatedAt = s.clock.Now()
+			if saveErr := s.store.SaveJob(context.Background(), job); saveErr != nil {
+				log.Printf("save failed webhook job %s: %v", job.ID, saveErr)
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) dispatchWebhook(job *Job) {
+	if s.notifier == nil || job.CallbackURL == "" {
+		return
+	}
+	if err := s.notifier.Notify(context.Background(), job); err != nil {
+		log.Printf("webhook notify job %s failed: %v", job.ID, err)
+	}
+}

--- a/internal/exchange/service_test.go
+++ b/internal/exchange/service_test.go
@@ -1,0 +1,147 @@
+package exchange_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/example/rate_limiter/internal/exchange"
+)
+
+type stubProvider struct {
+	mu    sync.Mutex
+	rate  *exchange.Rate
+	calls int
+	err   error
+}
+
+func (s *stubProvider) FetchRate(ctx context.Context, base, quote string) (*exchange.Rate, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	rateCopy := *s.rate
+	return &rateCopy, nil
+}
+
+type capturingNotifier struct {
+	mu   sync.Mutex
+	jobs []*exchange.Job
+	err  error
+}
+
+func (c *capturingNotifier) Notify(ctx context.Context, job *exchange.Job) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err != nil {
+		return c.err
+	}
+	jobCopy := *job
+	c.jobs = append(c.jobs, &jobCopy)
+	return nil
+}
+
+func TestServiceProcessesJobAndCachesRate(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis run: %v", err)
+	}
+	defer mr.Close()
+
+	redisClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer redisClient.Close()
+
+	provider := &stubProvider{rate: &exchange.Rate{Base: "EUR", Quote: "USD", Value: 1.1, AsOf: time.Now().Truncate(24 * time.Hour)}}
+	notifier := &capturingNotifier{}
+	store := exchange.NewRedisStore(redisClient, 24*time.Hour)
+
+	service := exchange.NewService(provider, store, notifier, exchange.WithProcessTimeout(time.Second))
+	defer service.Close()
+
+	ctx := context.Background()
+	job, err := service.RequestRate(ctx, "eur", "usd")
+	if err != nil {
+		t.Fatalf("request rate: %v", err)
+	}
+	if job.Status != exchange.JobStatusPending {
+		t.Fatalf("expected pending job, got %s", job.Status)
+	}
+
+	waitForStatus(t, service, job.ID, exchange.JobStatusCompleted)
+
+	cached, err := service.RequestRate(ctx, "eur", "usd")
+	if err != nil {
+		t.Fatalf("request cached rate: %v", err)
+	}
+	if cached.Status != exchange.JobStatusCompleted {
+		t.Fatalf("expected completed status, got %s", cached.Status)
+	}
+	if cached.Rate == nil {
+		t.Fatalf("expected cached rate in job")
+	}
+
+	provider.mu.Lock()
+	calls := provider.calls
+	provider.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("expected provider called once, got %d", calls)
+	}
+}
+
+func TestServiceDispatchesWebhook(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis run: %v", err)
+	}
+	defer mr.Close()
+
+	redisClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer redisClient.Close()
+
+	rate := &exchange.Rate{Base: "EUR", Quote: "USD", Value: 1.15, AsOf: time.Now().Truncate(24 * time.Hour)}
+	provider := &stubProvider{rate: rate}
+	notifier := &capturingNotifier{}
+	store := exchange.NewRedisStore(redisClient, 24*time.Hour)
+
+	service := exchange.NewService(provider, store, notifier, exchange.WithProcessTimeout(time.Second))
+	defer service.Close()
+
+	ctx := context.Background()
+	job, err := service.RequestRateWithWebhook(ctx, "eur", "usd", "https://example.com/callback")
+	if err != nil {
+		t.Fatalf("request rate with webhook: %v", err)
+	}
+	if job.Status != exchange.JobStatusPending {
+		t.Fatalf("expected pending job, got %s", job.Status)
+	}
+
+	waitForStatus(t, service, job.ID, exchange.JobStatusCompleted)
+
+	notifier.mu.Lock()
+	defer notifier.mu.Unlock()
+	if len(notifier.jobs) != 1 {
+		t.Fatalf("expected webhook to be invoked once, got %d", len(notifier.jobs))
+	}
+	if notifier.jobs[0].Rate == nil || notifier.jobs[0].Rate.Value != rate.Value {
+		t.Fatalf("webhook payload missing rate")
+	}
+}
+
+func waitForStatus(t *testing.T, service *exchange.Service, jobID string, status exchange.JobStatus) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		job, err := service.GetJob(context.Background(), jobID)
+		if err == nil && job.Status == status {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("job %s did not reach status %s", jobID, status)
+}

--- a/internal/exchange/store.go
+++ b/internal/exchange/store.go
@@ -1,0 +1,96 @@
+package exchange
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var ErrNotFound = errors.New("not found")
+
+// Store persists rates and job states.
+type Store interface {
+	SaveRate(ctx context.Context, rate *Rate) error
+	GetRateForDay(ctx context.Context, base, quote string, day time.Time) (*Rate, error)
+	SaveJob(ctx context.Context, job *Job) error
+	GetJob(ctx context.Context, id string) (*Job, error)
+}
+
+type RedisStore struct {
+	client    *redis.Client
+	retention time.Duration
+}
+
+func NewRedisStore(client *redis.Client, retention time.Duration) *RedisStore {
+	return &RedisStore{client: client, retention: retention}
+}
+
+func (s *RedisStore) SaveRate(ctx context.Context, rate *Rate) error {
+	payload, err := json.Marshal(rate)
+	if err != nil {
+		return fmt.Errorf("marshal rate: %w", err)
+	}
+	key := s.rateKey(rate.Base, rate.Quote, rate.AsOf)
+	if err := s.client.Set(ctx, key, payload, s.retention).Err(); err != nil {
+		return fmt.Errorf("save rate: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisStore) GetRateForDay(ctx context.Context, base, quote string, day time.Time) (*Rate, error) {
+	key := s.rateKey(base, quote, day)
+	data, err := s.client.Get(ctx, key).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get rate: %w", err)
+	}
+	var rate Rate
+	if err := json.Unmarshal(data, &rate); err != nil {
+		return nil, fmt.Errorf("unmarshal rate: %w", err)
+	}
+	return &rate, nil
+}
+
+func (s *RedisStore) SaveJob(ctx context.Context, job *Job) error {
+	payload, err := json.Marshal(job)
+	if err != nil {
+		return fmt.Errorf("marshal job: %w", err)
+	}
+	if err := s.client.Set(ctx, s.jobKey(job.ID), payload, s.retention).Err(); err != nil {
+		return fmt.Errorf("save job: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisStore) GetJob(ctx context.Context, id string) (*Job, error) {
+	data, err := s.client.Get(ctx, s.jobKey(id)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get job: %w", err)
+	}
+	var job Job
+	if err := json.Unmarshal(data, &job); err != nil {
+		return nil, fmt.Errorf("unmarshal job: %w", err)
+	}
+	return &job, nil
+}
+
+func (s *RedisStore) rateKey(base, quote string, day time.Time) string {
+	day = day.UTC()
+	base = strings.ToUpper(base)
+	quote = strings.ToUpper(quote)
+	return fmt.Sprintf("exchange:rate:%s:%s:%s", base, quote, day.Format("2006-01-02"))
+}
+
+func (s *RedisStore) jobKey(id string) string {
+	return fmt.Sprintf("exchange:job:%s", id)
+}

--- a/internal/exchange/types.go
+++ b/internal/exchange/types.go
@@ -1,0 +1,31 @@
+package exchange
+
+import "time"
+
+// Rate represents a currency exchange rate for a specific base/quote pair.
+type Rate struct {
+	Base  string    `json:"base"`
+	Quote string    `json:"quote"`
+	Value float64   `json:"value"`
+	AsOf  time.Time `json:"as_of"`
+}
+
+// JobStatus describes the state of an asynchronous exchange rate request.
+type JobStatus string
+
+const (
+	JobStatusPending   JobStatus = "pending"
+	JobStatusCompleted JobStatus = "completed"
+	JobStatusFailed    JobStatus = "failed"
+)
+
+// Job stores the status of asynchronous rate retrieval.
+type Job struct {
+	ID          string    `json:"id"`
+	Status      JobStatus `json:"status"`
+	Rate        *Rate     `json:"rate,omitempty"`
+	Failure     string    `json:"failure,omitempty"`
+	CallbackURL string    `json:"callback_url,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}

--- a/internal/http/handler/exchange.go
+++ b/internal/http/handler/exchange.go
@@ -1,0 +1,99 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/example/rate_limiter/internal/exchange"
+)
+
+type ExchangeHandler struct {
+	service *exchange.Service
+}
+
+func NewExchangeHandler(service *exchange.Service) *ExchangeHandler {
+	return &ExchangeHandler{service: service}
+}
+
+func (h *ExchangeHandler) Routes() chi.Router {
+	r := chi.NewRouter()
+	r.Post("/{base}/{quote}/webhook", h.requestWithWebhook)
+	r.Post("/{base}/{quote}/jobs", h.enqueue)
+	r.Get("/jobs/{jobID}", h.jobStatus)
+	r.Get("/{base}/{quote}/latest", h.latest)
+	return r
+}
+
+func (h *ExchangeHandler) requestWithWebhook(w http.ResponseWriter, r *http.Request) {
+	base := chi.URLParam(r, "base")
+	quote := chi.URLParam(r, "quote")
+	var payload struct {
+		CallbackURL string `json:"callback_url"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	job, err := h.service.RequestRateWithWebhook(r.Context(), base, quote, payload.CallbackURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	h.writeJobResponse(w, job)
+}
+
+func (h *ExchangeHandler) enqueue(w http.ResponseWriter, r *http.Request) {
+	base := chi.URLParam(r, "base")
+	quote := chi.URLParam(r, "quote")
+	job, err := h.service.RequestRate(r.Context(), base, quote)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	h.writeJobResponse(w, job)
+}
+
+func (h *ExchangeHandler) jobStatus(w http.ResponseWriter, r *http.Request) {
+	jobID := chi.URLParam(r, "jobID")
+	job, err := h.service.GetJob(r.Context(), jobID)
+	if err != nil {
+		if errors.Is(err, exchange.ErrNotFound) {
+			http.Error(w, "job not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(job)
+}
+
+func (h *ExchangeHandler) latest(w http.ResponseWriter, r *http.Request) {
+	base := chi.URLParam(r, "base")
+	quote := chi.URLParam(r, "quote")
+	rate, err := h.service.GetRateForDay(r.Context(), base, quote, time.Now())
+	if err != nil {
+		if errors.Is(err, exchange.ErrNotFound) {
+			http.Error(w, "rate not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(rate)
+}
+
+func (h *ExchangeHandler) writeJobResponse(w http.ResponseWriter, job *exchange.Job) {
+	status := http.StatusOK
+	if job.Status == exchange.JobStatusPending {
+		status = http.StatusAccepted
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(job)
+}

--- a/internal/http/handler/users_test.go
+++ b/internal/http/handler/users_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,28 +24,42 @@ func setupServer(t *testing.T) http.Handler {
 	t.Cleanup(mr.Close)
 
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	rl := limiter.NewRedis(client, 2, 24*time.Hour)
+	rl := limiter.NewRedis(client, 2, time.Second)
+
+	t.Cleanup(func() {
+		client.FlushAll(context.Background())
+		client.Close()
+	})
 
 	repo := user.NewMemoryRepository()
-	return httpserver.NewServer(repo, rl)
+	return httpserver.NewServer(repo, rl, nil)
 }
 
 func TestChangePasswordRateLimit(t *testing.T) {
+	// Arrange
 	srv := setupServer(t)
 
 	makeReq := func() *httptest.ResponseRecorder {
-		req := httptest.NewRequest(http.MethodPatch, "/v1/users/1/change-password", bytes.NewBufferString(`{"password":"x"}`))
+		reqBody := bytes.NewBufferString(`{"password":"x"}`)
+		req := httptest.NewRequest(http.MethodPatch, "/v1/users/1/change-password", reqBody)
 		rr := httptest.NewRecorder()
 		srv.ServeHTTP(rr, req)
 		return rr
 	}
 
-	for i := 0; i < 2; i++ {
-		if rr := makeReq(); rr.Code != http.StatusOK {
-			t.Fatalf("expected 200, got %d", rr.Code)
-		}
+	// Act
+	first := makeReq()
+	second := makeReq()
+	third := makeReq()
+
+	// Assert
+	if first.Code != http.StatusOK {
+		t.Fatalf("first request: expected %d, got %d", http.StatusOK, first.Code)
 	}
-	if rr := makeReq(); rr.Code != http.StatusTooManyRequests {
-		t.Fatalf("expected 429, got %d", rr.Code)
+	if second.Code != http.StatusOK {
+		t.Fatalf("second request: expected %d, got %d", http.StatusOK, second.Code)
+	}
+	if third.Code != http.StatusTooManyRequests {
+		t.Fatalf("third request: expected %d, got %d", http.StatusTooManyRequests, third.Code)
 	}
 }

--- a/internal/http/middleware/ratelimit.go
+++ b/internal/http/middleware/ratelimit.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/example/rate_limiter/internal/limiter"
+)
+
+// RateLimit returns an HTTP middleware that limits requests using the provided
+// RateLimiter and keyFn. If l.Allow reports that the request is not allowed,
+// the middleware responds with StatusTooManyRequests.
+func RateLimit(l limiter.RateLimiter, keyFn func(*http.Request) (string, error)) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key, err := keyFn(r)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			allowed, err := l.Allow(r.Context(), key)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if !allowed {
+				http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -6,18 +6,24 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 
+	"github.com/example/rate_limiter/internal/exchange"
 	"github.com/example/rate_limiter/internal/http/handler"
 	"github.com/example/rate_limiter/internal/limiter"
 	"github.com/example/rate_limiter/internal/user"
 )
 
 // NewServer builds HTTP server mux.
-func NewServer(repo user.Repository, rl limiter.RateLimiter) http.Handler {
+func NewServer(repo user.Repository, rl limiter.RateLimiter, exchangeService *exchange.Service) http.Handler {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 
 	userHandler := handler.NewUserHandler(repo, rl)
 	r.Mount("/v1/users", userHandler.Routes())
+
+	if exchangeService != nil {
+		exchangeHandler := handler.NewExchangeHandler(exchangeService)
+		r.Mount("/v1/rates", exchangeHandler.Routes())
+	}
 
 	return r
 }


### PR DESCRIPTION
## Summary
- add an exchange service that retrieves EUR/USD rates asynchronously and caches results for seven days
- expose HTTP endpoints for webhook-based delivery and polling-based retrieval of exchange rate jobs
- wire the new service into the server startup and cover webhook delivery and job processing with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6a875dc0c832490ac12deb594870d