### PR TITLE
Add circuit breaker demo (provider + consumer) with local implementation and tests

### DIFF
--- a/circuit_breaker/README.md
+++ b/circuit_breaker/README.md
@@ -1,0 +1,118 @@
+# Circuit Breaker demo на Go (провайдер курса валют + клиент)
+
+Этот каталог изолирует пример с паттерном **Circuit Breaker** от основного проекта rate limiter.
+
+## Что внутри
+
+- `cmd/exchange-provider` — простой HTTP сервис, отдающий курс USD→RUB.
+- `cmd/exchange-consumer` — второй сервис, который читает курс из provider через circuit breaker.
+- `internal/circuitbreaker` — локальная реализация circuit breaker.
+
+## Быстрый запуск
+
+Из корня репозитория:
+
+```bash
+go run ./circuit_breaker/cmd/exchange-provider
+```
+
+В другом терминале:
+
+```bash
+go run ./circuit_breaker/cmd/exchange-consumer
+```
+
+Проверка:
+
+```bash
+curl -s "http://localhost:8082/converted?amount=10"
+curl -s "http://localhost:8082/breaker"
+```
+
+---
+
+## Сценарий воспроизведения состояний
+
+### 1) Closed (нормальный режим)
+
+```bash
+curl -s "http://localhost:8082/converted?amount=5"
+curl -s "http://localhost:8082/breaker"
+```
+
+Ожидается `source=upstream`, `state=closed`.
+
+### 2) Open (апстрим падает)
+
+Перезапустить provider с ошибкой:
+
+```bash
+PROVIDER_FORCE_ERROR=true go run ./circuit_breaker/cmd/exchange-provider
+```
+
+Затем несколько запросов в consumer:
+
+```bash
+for i in {1..5}; do curl -s "http://localhost:8082/converted?amount=3"; echo; done
+curl -s "http://localhost:8082/breaker"
+```
+
+После достижения `CB_FAILURE_THRESHOLD` breaker станет `open`, и consumer начнет отдавать fallback без вызова апстрима.
+
+### 3) Half-open -> Closed (восстановление)
+
+Вернуть provider в норму:
+
+```bash
+PROVIDER_FORCE_ERROR=false go run ./circuit_breaker/cmd/exchange-provider
+```
+
+Подождать `CB_OPEN_TIMEOUT_MS` (по умолчанию 3000 мс) и снова вызвать consumer:
+
+```bash
+curl -s "http://localhost:8082/converted?amount=7"
+curl -s "http://localhost:8082/breaker"
+```
+
+При успешной пробе в `half-open` breaker вернется в `closed`.
+
+---
+
+## Конфигурация
+
+### Provider
+- `PROVIDER_ADDR` (default `:8081`)
+- `USD_RUB` (default `92.15`)
+- `PROVIDER_FORCE_ERROR` (default `false`)
+- `PROVIDER_DELAY_MS` (default `0`)
+
+### Consumer
+- `CONSUMER_ADDR` (default `:8082`)
+- `PROVIDER_URL` (default `http://localhost:8081/rate`)
+- `UPSTREAM_TIMEOUT_MS` (default `500`)
+- `FALLBACK_USD_RUB` (default `90.0`)
+- `CB_FAILURE_THRESHOLD` (default `3`)
+- `CB_OPEN_TIMEOUT_MS` (default `3000`)
+- `CB_HALF_OPEN_MAX_CALLS` (default `1`)
+
+---
+
+## Trade-offs и bottlenecks
+
+- Простая реализация без внешней библиотеки: легко читать, но меньше production-функций.
+- Один breaker на весь upstream: проще, но менее гибко.
+- Mutex внутри breaker может стать контеншном при очень высоком RPS.
+- Фиксированный fallback курс безопасен по доступности, но не всегда актуален по данным.
+
+---
+
+## Тесты
+
+```bash
+go test ./...
+```
+
+Покрыты:
+- переходы состояний circuit breaker,
+- success/error сценарии provider,
+- поведение consumer в healthy режиме и при открытом breaker.

--- a/circuit_breaker/cmd/exchange-consumer/main.go
+++ b/circuit_breaker/cmd/exchange-consumer/main.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/example/rate_limiter/circuit_breaker/internal/circuitbreaker"
+)
+
+type providerResponse struct {
+	Base      string             `json:"base"`
+	Timestamp time.Time          `json:"timestamp"`
+	Rates     map[string]float64 `json:"rates"`
+}
+
+type consumerServer struct {
+	providerURL string
+	httpClient  *http.Client
+	breaker     *circuitbreaker.CircuitBreaker
+	fallback    float64
+}
+
+func main() {
+	providerURL := getEnv("PROVIDER_URL", "http://localhost:8081/rate")
+	timeoutMs := mustAtoiEnv("UPSTREAM_TIMEOUT_MS", 500)
+	failureThreshold := uint(mustAtoiEnv("CB_FAILURE_THRESHOLD", 3))
+	openTimeoutMs := mustAtoiEnv("CB_OPEN_TIMEOUT_MS", 3000)
+	halfOpenCalls := uint(mustAtoiEnv("CB_HALF_OPEN_MAX_CALLS", 1))
+	fallback := mustAtofEnv("FALLBACK_USD_RUB", 90.0)
+
+	breaker := circuitbreaker.New(circuitbreaker.Config{
+		FailureThreshold: failureThreshold,
+		OpenTimeout:      time.Duration(openTimeoutMs) * time.Millisecond,
+		HalfOpenMaxCalls: halfOpenCalls,
+	})
+
+	srv := &consumerServer{
+		providerURL: providerURL,
+		httpClient: &http.Client{Timeout: time.Duration(timeoutMs) * time.Millisecond},
+		breaker:    breaker,
+		fallback:   fallback,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/converted", srv.convertedHandler)
+	mux.HandleFunc("/breaker", srv.breakerHandler)
+
+	addr := getEnv("CONSUMER_ADDR", ":8082")
+	log.Printf("exchange consumer listening on %s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (s *consumerServer) convertedHandler(w http.ResponseWriter, r *http.Request) {
+	amount := 1.0
+	if raw := r.URL.Query().Get("amount"); raw != "" {
+		parsed, err := strconv.ParseFloat(raw, 64)
+		if err != nil || parsed <= 0 {
+			http.Error(w, "amount must be positive number", http.StatusBadRequest)
+			return
+		}
+		amount = parsed
+	}
+
+	rate, source, err := s.fetchRate(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	payload := map[string]any{
+		"amount_usd": amount,
+		"rate":       rate,
+		"amount_rub": amount * rate,
+		"source":     source,
+		"state":      s.breaker.State(),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func (s *consumerServer) breakerHandler(w http.ResponseWriter, _ *http.Request) {
+	payload := map[string]any{"state": s.breaker.State()}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func (s *consumerServer) fetchRate(ctx context.Context) (rate float64, source string, err error) {
+	if err := s.breaker.Allow(); err != nil {
+		return s.fallback, "fallback_open_circuit", nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.providerURL, nil)
+	if err != nil {
+		return 0, "", fmt.Errorf("build request: %w", err)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		s.breaker.OnFailure()
+		return s.fallback, "fallback_upstream_error", nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 500 {
+		s.breaker.OnFailure()
+		return s.fallback, "fallback_upstream_error", nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		s.breaker.OnFailure()
+		return 0, "", errors.New("unexpected upstream status")
+	}
+
+	var payload providerResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		s.breaker.OnFailure()
+		return s.fallback, "fallback_upstream_error", nil
+	}
+
+	rate, ok := payload.Rates["RUB"]
+	if !ok {
+		s.breaker.OnFailure()
+		return 0, "", errors.New("upstream response missing RUB")
+	}
+
+	s.breaker.OnSuccess()
+	return rate, "upstream", nil
+}
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+func mustAtoiEnv(key string, fallback int) int {
+	value := getEnv(key, strconv.Itoa(fallback))
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		log.Fatalf("invalid %s=%s", key, value)
+	}
+	return parsed
+}
+
+func mustAtofEnv(key string, fallback float64) float64 {
+	value := getEnv(key, fmt.Sprintf("%.2f", fallback))
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		log.Fatalf("invalid %s=%s", key, value)
+	}
+	return parsed
+}

--- a/circuit_breaker/cmd/exchange-consumer/main_test.go
+++ b/circuit_breaker/cmd/exchange-consumer/main_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/example/rate_limiter/circuit_breaker/internal/circuitbreaker"
+)
+
+func TestConvertedHandlerUsesFallbackWhenOpen(t *testing.T) {
+	var calls atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		http.Error(w, "boom", http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+
+	srv := &consumerServer{
+		providerURL: upstream.URL,
+		httpClient:  &http.Client{Timeout: 100 * time.Millisecond},
+		breaker: circuitbreaker.New(circuitbreaker.Config{
+			FailureThreshold: 2,
+			OpenTimeout:      10 * time.Second,
+			HalfOpenMaxCalls: 1,
+		}),
+		fallback: 91.0,
+	}
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/converted?amount=2", nil)
+		w := httptest.NewRecorder()
+		srv.convertedHandler(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d status = %d, want %d", i, w.Code, http.StatusOK)
+		}
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("upstream calls = %d, want %d", got, 2)
+	}
+}
+
+func TestConvertedHandlerReturnsUpstreamWhenHealthy(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"base":"USD","timestamp":"2026-04-28T12:00:00Z","rates":{"RUB":95.5}}`))
+	}))
+	defer upstream.Close()
+
+	srv := &consumerServer{
+		providerURL: upstream.URL,
+		httpClient:  &http.Client{Timeout: 100 * time.Millisecond},
+		breaker: circuitbreaker.New(circuitbreaker.Config{
+			FailureThreshold: 2,
+			OpenTimeout:      time.Second,
+			HalfOpenMaxCalls: 1,
+		}),
+		fallback: 91.0,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/converted?amount=3", nil)
+	w := httptest.NewRecorder()
+	srv.convertedHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if payload["source"] != "upstream" {
+		t.Fatalf("source = %v, want upstream", payload["source"])
+	}
+}

--- a/circuit_breaker/cmd/exchange-provider/main.go
+++ b/circuit_breaker/cmd/exchange-provider/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+type response struct {
+	Base      string             `json:"base"`
+	Timestamp time.Time          `json:"timestamp"`
+	Rates     map[string]float64 `json:"rates"`
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/rate", rateHandler)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	addr := getEnv("PROVIDER_ADDR", ":8081")
+	log.Printf("exchange provider listening on %s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func rateHandler(w http.ResponseWriter, _ *http.Request) {
+	if delayMs, err := strconv.Atoi(getEnv("PROVIDER_DELAY_MS", "0")); err == nil && delayMs > 0 {
+		time.Sleep(time.Duration(delayMs) * time.Millisecond)
+	}
+
+	if getEnv("PROVIDER_FORCE_ERROR", "false") == "true" {
+		http.Error(w, "upstream provider temporary failure", http.StatusServiceUnavailable)
+		return
+	}
+
+	usdToRub, err := strconv.ParseFloat(getEnv("USD_RUB", "92.15"), 64)
+	if err != nil {
+		http.Error(w, "invalid USD_RUB env", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response{
+		Base:      "USD",
+		Timestamp: time.Now().UTC(),
+		Rates: map[string]float64{
+			"RUB": usdToRub,
+		},
+	})
+}
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}

--- a/circuit_breaker/cmd/exchange-provider/main_test.go
+++ b/circuit_breaker/cmd/exchange-provider/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestRateHandlerSuccess(t *testing.T) {
+	t.Setenv("PROVIDER_FORCE_ERROR", "false")
+	t.Setenv("USD_RUB", "100.25")
+	t.Setenv("PROVIDER_DELAY_MS", "0")
+
+	req := httptest.NewRequest(http.MethodGet, "/rate", nil)
+	w := httptest.NewRecorder()
+
+	rateHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var payload response
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if payload.Rates["RUB"] != 100.25 {
+		t.Fatalf("RUB rate = %v, want %v", payload.Rates["RUB"], 100.25)
+	}
+}
+
+func TestRateHandlerForcedError(t *testing.T) {
+	t.Setenv("PROVIDER_FORCE_ERROR", "true")
+	defer os.Unsetenv("PROVIDER_FORCE_ERROR")
+
+	req := httptest.NewRequest(http.MethodGet, "/rate", nil)
+	w := httptest.NewRecorder()
+
+	rateHandler(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}

--- a/circuit_breaker/internal/circuitbreaker/breaker.go
+++ b/circuit_breaker/internal/circuitbreaker/breaker.go
@@ -1,0 +1,140 @@
+package circuitbreaker
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+var ErrCircuitOpen = errors.New("circuit breaker is open")
+
+type State string
+
+const (
+	StateClosed   State = "closed"
+	StateOpen     State = "open"
+	StateHalfOpen State = "half-open"
+)
+
+type Config struct {
+	FailureThreshold uint
+	OpenTimeout      time.Duration
+	HalfOpenMaxCalls uint
+}
+
+type CircuitBreaker struct {
+	mu sync.Mutex
+
+	cfg Config
+
+	state      State
+	failures   uint
+	successes  uint
+	halfCalls  uint
+	openedAt   time.Time
+	now        func() time.Time
+}
+
+func New(cfg Config) *CircuitBreaker {
+	if cfg.FailureThreshold == 0 {
+		cfg.FailureThreshold = 3
+	}
+	if cfg.OpenTimeout <= 0 {
+		cfg.OpenTimeout = 5 * time.Second
+	}
+	if cfg.HalfOpenMaxCalls == 0 {
+		cfg.HalfOpenMaxCalls = 1
+	}
+
+	return &CircuitBreaker{
+		cfg:   cfg,
+		state: StateClosed,
+		now:   time.Now,
+	}
+}
+
+func (cb *CircuitBreaker) Allow() error {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	now := cb.now()
+
+	switch cb.state {
+	case StateOpen:
+		if now.Sub(cb.openedAt) >= cb.cfg.OpenTimeout {
+			cb.state = StateHalfOpen
+			cb.halfCalls = 0
+			cb.successes = 0
+		} else {
+			return ErrCircuitOpen
+		}
+	case StateHalfOpen:
+		if cb.halfCalls >= cb.cfg.HalfOpenMaxCalls {
+			return ErrCircuitOpen
+		}
+	}
+
+	if cb.state == StateHalfOpen {
+		cb.halfCalls++
+	}
+
+	return nil
+}
+
+func (cb *CircuitBreaker) OnSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case StateClosed:
+		cb.failures = 0
+	case StateHalfOpen:
+		cb.successes++
+		if cb.successes >= cb.cfg.HalfOpenMaxCalls {
+			cb.state = StateClosed
+			cb.resetCounters()
+		}
+	}
+}
+
+func (cb *CircuitBreaker) OnFailure() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	now := cb.now()
+
+	switch cb.state {
+	case StateClosed:
+		cb.failures++
+		if cb.failures >= cb.cfg.FailureThreshold {
+			cb.tripOpen(now)
+		}
+	case StateHalfOpen:
+		cb.tripOpen(now)
+	}
+}
+
+func (cb *CircuitBreaker) State() State {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	if cb.state == StateOpen && cb.now().Sub(cb.openedAt) >= cb.cfg.OpenTimeout {
+		cb.state = StateHalfOpen
+		cb.halfCalls = 0
+		cb.successes = 0
+	}
+
+	return cb.state
+}
+
+func (cb *CircuitBreaker) resetCounters() {
+	cb.failures = 0
+	cb.successes = 0
+	cb.halfCalls = 0
+}
+
+func (cb *CircuitBreaker) tripOpen(now time.Time) {
+	cb.state = StateOpen
+	cb.openedAt = now
+	cb.resetCounters()
+}

--- a/circuit_breaker/internal/circuitbreaker/breaker_test.go
+++ b/circuit_breaker/internal/circuitbreaker/breaker_test.go
@@ -1,0 +1,78 @@
+package circuitbreaker
+
+import (
+	"testing"
+	"time"
+)
+
+func TestOpensAfterFailureThreshold(t *testing.T) {
+	cb := New(Config{FailureThreshold: 2, OpenTimeout: time.Second, HalfOpenMaxCalls: 1})
+
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("allow failed in closed state: %v", err)
+	}
+	cb.OnFailure()
+
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("allow failed before threshold: %v", err)
+	}
+	cb.OnFailure()
+
+	if got := cb.State(); got != StateOpen {
+		t.Fatalf("state = %s, want %s", got, StateOpen)
+	}
+	if err := cb.Allow(); err != ErrCircuitOpen {
+		t.Fatalf("allow error = %v, want %v", err, ErrCircuitOpen)
+	}
+}
+
+func TestHalfOpenThenCloseOnSuccess(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	cb := New(Config{FailureThreshold: 1, OpenTimeout: 5 * time.Second, HalfOpenMaxCalls: 2})
+	cb.now = func() time.Time { return now }
+
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("allow failed: %v", err)
+	}
+	cb.OnFailure()
+
+	now = now.Add(6 * time.Second)
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("allow in half-open failed: %v", err)
+	}
+	cb.OnSuccess()
+
+	if got := cb.State(); got != StateHalfOpen {
+		t.Fatalf("state after one success = %s, want %s", got, StateHalfOpen)
+	}
+
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("second half-open allow failed: %v", err)
+	}
+	cb.OnSuccess()
+
+	if got := cb.State(); got != StateClosed {
+		t.Fatalf("state after successful probes = %s, want %s", got, StateClosed)
+	}
+}
+
+func TestHalfOpenFailureTripsBackToOpen(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	cb := New(Config{FailureThreshold: 1, OpenTimeout: time.Second, HalfOpenMaxCalls: 1})
+	cb.now = func() time.Time { return now }
+
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("allow failed: %v", err)
+	}
+	cb.OnFailure()
+
+	now = now.Add(2 * time.Second)
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("allow in half-open failed: %v", err)
+	}
+	cb.OnFailure()
+
+	if got := cb.State(); got != StateOpen {
+		t.Fatalf("state = %s, want %s", got, StateOpen)
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide an isolated, runnable demo of the Circuit Breaker pattern in Go demonstrating upstream protection and fallback behavior with a minimal, local implementation for learning and local testing.
- Offer a small end-to-end example (provider + consumer) that can be used to reproduce `closed`/`open`/`half-open` transitions and to exercise the integration of the breaker with HTTP calls.

### Description

- Add a local circuit breaker implementation in `internal/circuitbreaker` exposing `CircuitBreaker` and methods like `Allow`, `OnSuccess`, and `OnFailure` with configurable thresholds and timeouts. 
- Add `cmd/exchange-provider` HTTP service that serves a JSON USD→RUB rate and supports simulated delay and forced error via environment variables. 
- Add `cmd/exchange-consumer` HTTP service that queries the provider through the circuit breaker, returns fallback values when open, and exposes `/converted` and `/breaker` endpoints. 
- Add `circuit_breaker/README.md` documenting how to run the demo, configuration variables, scenarios, and trade-offs.

### Testing

- Run `go test ./...` covering the breaker unit tests, provider handler tests, and consumer handler tests. 
- Tests include `internal/circuitbreaker/breaker_test.go` for state transitions and probe logic. 
- Tests include `cmd/exchange-provider/main_test.go` for success and forced-error scenarios, and `cmd/exchange-consumer/main_test.go` for fallback and healthy upstream behavior. 
- All automated tests passed successfully when executed with `go test ./...`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bb9caaf083249bb23067acd386b2)